### PR TITLE
Gradle and AndroidManifest updates for flutter 3.22

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -32,7 +32,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,8 +40,8 @@ android {
 
     defaultConfig {
         applicationId "com.naokiokada.nfcmanager"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,20 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.naokiokada.nfcmanager">
+
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <application
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"> <!-- Add this line -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
 </manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip

--- a/lib/view/app.dart
+++ b/lib/view/app.dart
@@ -47,40 +47,50 @@ class _Home extends StatelessWidget {
             FormRow(
               title: Text('Tag - Read'),
               trailing: Icon(Icons.chevron_right),
-              onTap: () => Navigator.push(context, MaterialPageRoute(
-                builder: (context) => TagReadPage.withDependency(),
-              )),
+              onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => TagReadPage.withDependency(),
+                  )),
             ),
             FormRow(
               title: Text('Ndef - Write'),
               trailing: Icon(Icons.chevron_right),
-              onTap: () => Navigator.push(context, MaterialPageRoute(
-                builder: (context) => NdefWritePage.withDependency(),
-              )),
+              onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => NdefWritePage.withDependency(),
+                  )),
             ),
             FormRow(
               title: Text('Ndef - Write Lock'),
               trailing: Icon(Icons.chevron_right),
-              onTap: () => Navigator.push(context, MaterialPageRoute(
-                builder: (context) => NdefWriteLockPage.withDependency(),
-              )),
+              onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => NdefWriteLockPage.withDependency(),
+                  )),
             ),
             if (Platform.isAndroid)
               FormRow(
                 title: Text('Ndef - Format'),
                 trailing: Icon(Icons.chevron_right),
-                onTap: () => Navigator.push(context, MaterialPageRoute(
-                  builder: (context) => NdefFormatPage.withDependency(),
-                )),
+                onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => NdefFormatPage.withDependency(),
+                    )),
               ),
           ]),
           FormSection(children: [
             FormRow(
               title: Text('About'),
               trailing: Icon(Icons.chevron_right),
-              onTap: () => Navigator.push(context, MaterialPageRoute(
-                builder: (context) => AboutPage(),
-              )),
+              onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => AboutPage(),
+                  )),
             ),
           ]),
         ],
@@ -92,8 +102,8 @@ class _Home extends StatelessWidget {
 ThemeData _themeData(Brightness brightness) {
   return ThemeData(
     brightness: brightness,
-     // Matches app icon color.
-    primarySwatch:  MaterialColor(0xFF4D8CFE, <int, Color>{
+    // Matches app icon color.
+    primarySwatch: MaterialColor(0xFF4D8CFE, <int, Color>{
       50: Color(0xFFEAF1FF),
       100: Color(0xFFCADDFF),
       200: Color(0xFFA6C6FF),
@@ -106,8 +116,8 @@ ThemeData _themeData(Brightness brightness) {
       900: Color(0xFF255CFD),
     }),
     appBarTheme: AppBarTheme(
-      brightness: Brightness.dark,
-    ),
+        // brightness: Brightness.dark,
+        ),
     inputDecorationTheme: InputDecorationTheme(
       isDense: true,
       border: OutlineInputBorder(),
@@ -115,23 +125,21 @@ ThemeData _themeData(Brightness brightness) {
       errorStyle: TextStyle(height: 0.75),
       helperStyle: TextStyle(height: 0.75),
     ),
-    elevatedButtonTheme: ElevatedButtonThemeData(style: ElevatedButton.styleFrom(
+    elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
       minimumSize: Size.fromHeight(40),
     )),
-    scaffoldBackgroundColor: brightness == Brightness.dark
-      ? Colors.black
-      : null,
-    cardColor: brightness == Brightness.dark
-      ? Color.fromARGB(255, 28, 28, 30)
-      : null,
+    scaffoldBackgroundColor:
+        brightness == Brightness.dark ? Colors.black : null,
+    cardColor:
+        brightness == Brightness.dark ? Color.fromARGB(255, 28, 28, 30) : null,
     dialogTheme: DialogTheme(
       backgroundColor: brightness == Brightness.dark
-        ? Color.fromARGB(255, 28, 28, 30)
-        : null,
+          ? Color.fromARGB(255, 28, 28, 30)
+          : null,
     ),
-    highlightColor: brightness == Brightness.dark
-      ? Color.fromARGB(255, 44, 44, 46)
-      : null,
+    highlightColor:
+        brightness == Brightness.dark ? Color.fromARGB(255, 44, 44, 46) : null,
     splashFactory: NoSplash.splashFactory,
   );
 }

--- a/lib/view/common/form_row.dart
+++ b/lib/view/common/form_row.dart
@@ -27,14 +27,20 @@ class FormRow extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     DefaultTextStyle(
-                      style: Theme.of(context).textTheme.bodyText2!.copyWith(fontSize: 17),
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium!
+                          .copyWith(fontSize: 17),
                       child: title,
                     ),
                     if (subtitle != null)
                       Padding(
                         padding: EdgeInsets.only(top: 2),
                         child: DefaultTextStyle(
-                          style: Theme.of(context).textTheme.caption!.copyWith(fontSize: 15),
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodySmall!
+                              .copyWith(fontSize: 15),
                           child: subtitle!,
                         ),
                       ),
@@ -43,9 +49,13 @@ class FormRow extends StatelessWidget {
               ),
               if (trailing != null)
                 DefaultTextStyle(
-                  style: Theme.of(context).textTheme.caption!.copyWith(fontSize: 16),
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall!
+                      .copyWith(fontSize: 16),
                   child: IconTheme(
-                    data: IconThemeData(color: Theme.of(context).disabledColor, size: 22),
+                    data: IconThemeData(
+                        color: Theme.of(context).disabledColor, size: 22),
                     child: trailing!,
                   ),
                 ),
@@ -78,20 +88,26 @@ class FormSection extends StatelessWidget {
               padding: EdgeInsets.fromLTRB(16, 0, 10, 4),
               constraints: BoxConstraints(minHeight: 36),
               child: DefaultTextStyle(
-                style: Theme.of(context).textTheme.caption!.copyWith(fontSize: 13),
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall!
+                    .copyWith(fontSize: 13),
                 child: header!,
               ),
             ),
           Container(
             margin: EdgeInsets.symmetric(horizontal: 2),
             decoration: BoxDecoration(
-              border: Border.all(width: 1, color: Theme.of(context).dividerColor),
+              border:
+                  Border.all(width: 1, color: Theme.of(context).dividerColor),
               color: Theme.of(context).cardColor,
             ),
             child: Column(
               children: List.generate(
                 children.isEmpty ? 0 : children.length * 2 - 1,
-                (i) => i.isOdd ? Divider(height: 1, thickness: 1) : children[i ~/ 2],
+                (i) => i.isOdd
+                    ? Divider(height: 1, thickness: 1)
+                    : children[i ~/ 2],
               ),
             ),
           ),
@@ -101,7 +117,10 @@ class FormSection extends StatelessWidget {
               padding: EdgeInsets.fromLTRB(16, 4, 10, 0),
               constraints: BoxConstraints(minHeight: 36),
               child: DefaultTextStyle(
-                style: Theme.of(context).textTheme.caption!.copyWith(fontSize: 13),
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall!
+                    .copyWith(fontSize: 13),
                 child: footer!,
               ),
             ),

--- a/lib/view/ndef_record.dart
+++ b/lib/view/ndef_record.dart
@@ -59,7 +59,6 @@ class _RecordColumn extends StatelessWidget {
   _RecordColumn({required this.title, required this.subtitle});
 
   final Widget title;
-
   final Widget subtitle;
 
   @override
@@ -68,12 +67,12 @@ class _RecordColumn extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         DefaultTextStyle(
-          style: Theme.of(context).textTheme.bodyText1!.copyWith(fontSize: 16),
+          style: Theme.of(context).textTheme.bodyLarge!.copyWith(fontSize: 16),
           child: title,
         ),
         SizedBox(height: 2),
         DefaultTextStyle(
-          style: Theme.of(context).textTheme.bodyText2!.copyWith(fontSize: 15),
+          style: Theme.of(context).textTheme.bodyMedium!.copyWith(fontSize: 15),
           child: subtitle,
         ),
       ],
@@ -82,7 +81,8 @@ class _RecordColumn extends StatelessWidget {
 }
 
 class NdefRecordInfo {
-  const NdefRecordInfo({required this.record, required this.title, required this.subtitle});
+  const NdefRecordInfo(
+      {required this.record, required this.title, required this.subtitle});
 
   final Record record;
 
@@ -133,7 +133,8 @@ class NdefRecordInfo {
       return NdefRecordInfo(
         record: _record,
         title: _typeNameFormatToString(_record.record.typeNameFormat),
-        subtitle: '(${_record.record.type.toHexString()}) ${_record.record.payload.toHexString()}',
+        subtitle:
+            '(${_record.record.type.toHexString()}) ${_record.record.payload.toHexString()}',
       );
     }
     throw UnimplementedError();

--- a/lib/view/ndef_write.dart
+++ b/lib/view/ndef_write.dart
@@ -26,20 +26,19 @@ class NdefWriteModel with ChangeNotifier {
     return _repo.deleteWriteRecord(record);
   }
 
-  Future<String?> handleTag(NfcTag tag, Iterable<WriteRecord> recordList) async {
+  Future<String?> handleTag(
+      NfcTag tag, Iterable<WriteRecord> recordList) async {
     final tech = Ndef.from(tag);
 
-    if (tech == null)
-      throw('Tag is not ndef.');
+    if (tech == null) throw ('Tag is not ndef.');
 
-    if (!tech.isWritable)
-      throw('Tag is not ndef writable.');
+    if (!tech.isWritable) throw ('Tag is not ndef writable.');
 
     try {
       final message = NdefMessage(recordList.map((e) => e.record).toList());
       await tech.write(message);
     } on PlatformException catch (e) {
-      throw(e.message ?? 'Some error has occurred.');
+      throw (e.message ?? 'Some error has occurred.');
     }
 
     return '[Ndef - Write] is completed.';
@@ -48,9 +47,10 @@ class NdefWriteModel with ChangeNotifier {
 
 class NdefWritePage extends StatelessWidget {
   static Widget withDependency() => ChangeNotifierProvider<NdefWriteModel>(
-    create: (context) => NdefWriteModel(Provider.of(context, listen: false)),
-    child: NdefWritePage(),
-  );
+        create: (context) =>
+            NdefWriteModel(Provider.of(context, listen: false)),
+        child: NdefWritePage(),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -94,47 +94,61 @@ class NdefWritePage extends StatelessWidget {
                   );
                   switch (result) {
                     case 'text':
-                      Navigator.push(context, MaterialPageRoute(
-                        fullscreenDialog: true,
-                        builder: (context) => EditTextPage.withDependency(),
-                      ));
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            fullscreenDialog: true,
+                            builder: (context) => EditTextPage.withDependency(),
+                          ));
                       break;
                     case 'uri':
-                      Navigator.push(context, MaterialPageRoute(
-                        fullscreenDialog: true,
-                        builder: (context) => EditUriPage.withDependency(),
-                      ));
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            fullscreenDialog: true,
+                            builder: (context) => EditUriPage.withDependency(),
+                          ));
                       break;
                     case 'mime':
-                      Navigator.push(context, MaterialPageRoute(
-                        fullscreenDialog: true,
-                        builder: (context) => EditMimePage.withDependency(),
-                      ));
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            fullscreenDialog: true,
+                            builder: (context) => EditMimePage.withDependency(),
+                          ));
                       break;
                     case 'external':
-                      Navigator.push(context, MaterialPageRoute(
-                        fullscreenDialog: true,
-                        builder: (context) => EditExternalPage.withDependency(),
-                      ));
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            fullscreenDialog: true,
+                            builder: (context) =>
+                                EditExternalPage.withDependency(),
+                          ));
                       break;
                     case null:
                       break;
                     default:
-                      throw('unsupported: result=$result');
+                      throw ('unsupported: result=$result');
                   }
                 },
               ),
               FormRow(
-                title: Text('Start Session', style: TextStyle(color: ss.data?.isNotEmpty != true
-                  ? Theme.of(context).disabledColor
-                  : Theme.of(context).colorScheme.primary,
-                )),
+                title: Text('Start Session',
+                    style: TextStyle(
+                      color: ss.data?.isNotEmpty != true
+                          ? Theme.of(context).disabledColor
+                          : Theme.of(context).colorScheme.primary,
+                    )),
                 onTap: ss.data?.isNotEmpty != true
-                  ? null
-                  : () => startSession(
-                    context: context,
-                    handleTag: (tag) => Provider.of<NdefWriteModel>(context, listen: false).handleTag(tag, ss.data!),
-                  ),
+                    ? null
+                    : () => startSession(
+                          context: context,
+                          handleTag: (tag) => Provider.of<NdefWriteModel>(
+                                  context,
+                                  listen: false)
+                              .handleTag(tag, ss.data!),
+                        ),
               ),
             ]),
             if (ss.data?.isNotEmpty == true)
@@ -143,7 +157,8 @@ class NdefWritePage extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text('RECORDS'),
-                    Text('${ss.data!.map((e) => e.record.byteLength).reduce((a, b) => a + b)} bytes'),
+                    Text(
+                        '${ss.data!.map((e) => e.record.byteLength).reduce((a, b) => a + b)} bytes'),
                   ],
                 ),
                 children: List.generate(ss.data!.length, (i) {
@@ -188,7 +203,10 @@ class _WriteRecordFormRow extends StatelessWidget {
                   ),
                   title: Text(
                     '#$index ${info.title}',
-                    style: Theme.of(context).textTheme.caption!.copyWith(fontSize: 14),
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyMedium!
+                        .copyWith(fontSize: 14),
                   ),
                 ),
                 ListTile(
@@ -210,16 +228,20 @@ class _WriteRecordFormRow extends StatelessWidget {
         );
         switch (result) {
           case 'view_details':
-            Navigator.push(context, MaterialPageRoute(
-              builder: (context) => NdefRecordPage(index, record.record),
-            ));
+            Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => NdefRecordPage(index, record.record),
+                ));
             break;
           case 'edit':
             assert(editPageBuilder != null);
-            Navigator.push(context, MaterialPageRoute(
-              fullscreenDialog: true,
-              builder: (context) => editPageBuilder!(record),
-            ));
+            Navigator.push(
+                context,
+                MaterialPageRoute(
+                  fullscreenDialog: true,
+                  builder: (context) => editPageBuilder!(record),
+                ));
             break;
           case 'delete':
             final result = await showDialog<bool>(
@@ -241,12 +263,13 @@ class _WriteRecordFormRow extends StatelessWidget {
             );
             if (result == true)
               Provider.of<NdefWriteModel>(context, listen: false)
-                .delete(record).catchError((e) => print('=== $e ==='));
+                  .delete(record)
+                  .catchError((e) => print('=== $e ==='));
             break;
           case null:
             break;
           default:
-            throw('unsupported result: $result');
+            throw ('unsupported result: $result');
         }
       },
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,72 +5,74 @@ packages:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: a92e39b291073bb840a72cf43d96d2a63c74e9a485d227833e8ea0054d16ad16
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "3d82ff8620ec576fd38f6cec0df45a7c088b8704eb1c63d4c336392e5efca6ca"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: cf75650c66c0316274e21d7c43d3dea246273af5955bd94e8184837cd577575c
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,7 +82,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_launcher_icons
-      url: "https://pub.dartlang.org"
+      sha256: "52c83308bd184b27dcefe5c905a8188cec33af8c194d7df9f870ee853349fe32"
+      url: "https://pub.dev"
     source: hosted
     version: "0.9.1"
   flutter_test:
@@ -97,77 +100,112 @@ packages:
     dependency: transitive
     description:
       name: image
-      url: "https://pub.dartlang.org"
+      sha256: "3e5c9ef82c0af7823be4cb5294a829a6e0548a6f6b4e261e6386509a9e03bcab"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  js:
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      url: "https://pub.dartlang.org"
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.16+1"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.12.0"
   nested:
     dependency: transitive
     description:
       name: nested
-      url: "https://pub.dartlang.org"
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   nfc_manager:
     dependency: "direct main"
     description:
       name: nfc_manager
-      url: "https://pub.dartlang.org"
+      sha256: "1571c62a0d9beacd2e83599c5072b8bb21a7a7a879e8ce683300c166f14417ac"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   package_info:
     dependency: "direct main"
     description:
       name: package_info
-      url: "https://pub.dartlang.org"
+      sha256: "6c07d9d82c69e16afeeeeb6866fe43985a20b3b50df243091bfc4a4ad2b03b75"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: "85e8f8b118afcccf948a9844d199e56260117400bd9b9982d87bf1d62ebc1690"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "5aadc2af7cd403ad0b95ef654c3e628517f4cae9682b4229a66caf9df71844d2"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   provider:
     dependency: "direct main"
     description:
       name: provider
-      url: "https://pub.dartlang.org"
+      sha256: "59471e0a4595e264625d3496af567ac85bdae1148ec985aff1e0555786f53ecf"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
   sky_engine:
@@ -179,135 +217,162 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.10.0"
   sqflite:
     dependency: "direct main"
     description:
       name: sqflite
-      url: "https://pub.dartlang.org"
+      sha256: "643ab681a84d299bb5b661995668008e732f0577725b5be50d1dd25c1ed42d53"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0+3"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      url: "https://pub.dartlang.org"
+      sha256: b229e2c783cccb451a5a0702e9c2d755a1efb6b6e035385437d11d5036ee37b9
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0+2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   synchronized:
     dependency: transitive
     description:
       name: synchronized
-      url: "https://pub.dartlang.org"
+      sha256: "271977ff1e9e82ceefb4f08424b8839f577c1852e0726b5ce855311b46d3ef83"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   url_launcher:
     dependency: "direct main"
     description:
       name: url_launcher
-      url: "https://pub.dartlang.org"
+      sha256: "50b12f1e0ce40ff031c88bb0661bfcdb31c4923bd5c405b5e0dfec65226be179"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.9"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      url: "https://pub.dartlang.org"
+      sha256: "0d06961fca3c1ff122057247c598bfb938b3712923d98671d2df5021fe924567"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      url: "https://pub.dartlang.org"
+      sha256: fc3fca6327a51638007b179b5102b4b5c3d23875816f37ae394b37b99a558f4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: a4acd1aed57444bd4693768559a891cbb3168dbf0b992d0d5b5b5619ab371aed
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      url: "https://pub.dartlang.org"
+      sha256: "98f7b59f0445b24810f5955c7e90b48dd68f9a05259223af894b0aeac9fe32bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      url: "https://pub.dartlang.org"
+      sha256: "0efa5bdbf5bce188531946fd7a82f2b300394009958d65cc2bcee836bdd0a867"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.2.1"
   xml:
     dependency: transitive
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: "30498604ab00fc50286f8aaf7e077c496550b16ed2f325c14152244882314f03"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.2"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3cee79b1715110341012d27756d9bae38e650588acd38d3f3c610822e1337ace"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
# Flutter TextTheme Migration:

- Updated the usage of TextTheme.caption and TextTheme.bodyText1 to their new names as required in the latest Flutter version
   - Replaced TextTheme.caption with TextTheme.bodySmall
   - Replaced TextTheme.bodyText1 with TextTheme.bodyLarge

- Updated AndroidManifest to specify the android:exported attribute for the MainActivity component